### PR TITLE
Add the 'LineNo' to the cache key

### DIFF
--- a/avalara/facade.py
+++ b/avalara/facade.py
@@ -222,6 +222,6 @@ def _build_cache_key(payload):
         parts.append(str(address['AddressCode']))
 
     for line in payload['Lines']:
-        parts.extend([line['Amount'], line['ItemCode'], str(line['Qty'])])
+        parts.extend([line['Amount'], line['ItemCode'], str(line['Qty']), str(line['LineNo'])])
 
     return "avalara-%s" % zlib.crc32("-".join(parts))


### PR DESCRIPTION
### What is the problem / feature ?

If the user removes an item from the basket and re-adds it later on (same quantity) the `_build_cache_key` method will return the same key, and `data` will be loaded from the cache. Problem is that the `line.id` has changed and `RuntimeError` will be raised (`Unable to determine taxes on basket`).
### How did it get fixed / implemented ?

Add the `LineNo` to the caching key.

_Here is a cute animal picture for your troubles..._

![image](https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcTTJAYw95sf7jMpVRYccm33OxuU6-txAUWdlYEWtxzjVOgkUsmVDA)
