### PR TITLE
django-oscar v1.0 compatibility around shipping

### DIFF
--- a/avalara/gateway.py
+++ b/avalara/gateway.py
@@ -2,7 +2,7 @@ import logging
 import pprint
 
 from django.conf import settings
-from django.utils import simplejson as json
+import json
 import purl
 import requests
 

--- a/avalara/models.py
+++ b/avalara/models.py
@@ -2,7 +2,7 @@ import pprint
 from decimal import Decimal as D
 
 from django.db import models
-from django.utils import simplejson as json
+import json
 
 
 class Request(models.Model):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='django-oscar-avalara',
       packages=find_packages(exclude=['sandbox*', 'tests*']),
       include_package_data=True,
       install_requires=[
-          'django-oscar>=0.6',
+          'django-oscar>=1.0',
           'requests',
           'purl>=0.8',
       ],

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -25,16 +25,17 @@ def build_submission():
     shipping_address = G(models.ShippingAddress,
                          phone_number='')
     shipping_method = methods.FixedPrice(D('0.99'))
-    shipping_method.set_basket(basket)
+    shipping_charge = shipping_method.calculate(basket)
 
     calculator = calculators.OrderTotalCalculator()
-    total = calculator.calculate(basket, shipping_method)
+    total = calculator.calculate(basket, shipping_charge)
 
     return {
         'user': None,
         'basket': basket,
         'shipping_address': shipping_address,
         'shipping_method': shipping_method,
+        'shipping_charge': shipping_charge,
         'order_total': total,
         'order_kwargs': {},
         'payment_kwargs': {}}
@@ -45,7 +46,7 @@ class TestApplyTaxesToSubmission(TestCase):
     def test_sets_taxes_on_basket_and_shipping_method(self):
         submission = build_submission()
         self.assertFalse(submission['basket'].is_tax_known)
-        self.assertFalse(submission['shipping_method'].is_tax_known)
+        self.assertFalse(submission['shipping_charge'].is_tax_known)
 
         with mock.patch('requests.request') as mocked_request:
             mocked_response = mock.Mock()
@@ -57,4 +58,4 @@ class TestApplyTaxesToSubmission(TestCase):
             avalara.apply_taxes_to_submission(submission)
 
         self.assertTrue(submission['basket'].is_tax_known)
-        self.assertTrue(submission['shipping_method'].is_tax_known)
+        self.assertTrue(submission['shipping_charge'].is_tax_known)


### PR DESCRIPTION
### What is the problem / feature ?

The `django-oscar` shipping method API has been altered to avoid potential thread-safety issues with the [v1.0 release](https://github.com/django-oscar/django-oscar/blob/master/docs/source/releases/v1.0.rst#shipping)
This API isn't compatible with `django-oscar` >= 1.0
### How did it get fixed / implemented ?
- Add `shipping_charge` property to the submission dict so that `apply_taxes_to_submission` continues to work with `PaymentDetailsView`
- Change the `facade.apply_taxes` signature to accept `shipping_charge`
- Change the `facade.fetch_tax_info` signature to accept `shipping_charge` and remove the use of `charge_excl_tax` property on the `shipping_method`
- Fix tests

_Here is a cute animal picture for your troubles..._

![image](https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcRGNwnd6qrOy551s5jM2w5UsRKMBLj3sfaklWDgieVNC6a9PRav)
