### PR TITLE
Fix submit method

### DIFF
--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -59,3 +59,18 @@ class TestApplyTaxesToSubmission(TestCase):
 
         self.assertTrue(submission['basket'].is_tax_known)
         self.assertTrue(submission['shipping_charge'].is_tax_known)
+
+
+class TestSubmitOrder(TestCase):
+
+    def test_build_payload(self):
+        shipping_address = G(models.ShippingAddress,
+                             phone_number='')
+        order = factories.create_order(shipping_address=shipping_address)
+        # Ensure partner has an address
+        partner = order.lines.all()[0].stockrecord.partner
+        G(partner_models.PartnerAddress, partner=partner)
+
+        with mock.patch('avalara.gateway.post_tax') as mocked_post_tax:
+            avalara.submit(order)
+            self.assertTrue(mocked_post_tax.called)


### PR DESCRIPTION
### What is the problem / feature ?
- The `AbstractOrder` model does not have the  `shipping_charge` property.
- Basket line model and order line model are different models, and `order` `AbstractLine` does not have the `line_price_excl_tax_incl_discounts` property.
- `order.shipping_method` can be a `django.utils.functional.__proxy__` object.
### How did it get fixed / implemented ?
- use `shipping_excl_tax` instead of `shipping_charge` on the order model
- get the `Amount` from `line.line_price_excl_tax` if the line is an `OrderLine`
- call `unicode()` with `order.shipping_method` as argument

_Here is a cute animal picture for your troubles..._
![image](https://cloud.githubusercontent.com/assets/765961/5495500/80636f7a-86bb-11e4-9616-af90d674797a.jpg)
